### PR TITLE
Remove isort

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,12 @@ lint: style
 .PHONY: style
 style:
 	poetry run black .
-	poetry run isort .
 	poetry run mypy --install-types --non-interactive autodonate tests
 	poetry run doc8 -q docs
 
 .PHONY: unit
 unit:
-	poetry run python manage.py migrate
-	poetry run pytest
+	poetry run pytest tests
 
 .PHONY: package
 package:

--- a/poetry.lock
+++ b/poetry.lock
@@ -450,20 +450,6 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "isort"
-version = "5.10.1"
-description = "A Python utility / library to sort Python imports."
-category = "dev"
-optional = false
-python-versions = ">=3.6.1,<4.0"
-
-[package.extras]
-pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
-requirements_deprecated_finder = ["pipreqs", "pip-api"]
-colors = ["colorama (>=0.4.3,<0.5.0)"]
-plugins = ["setuptools"]
-
-[[package]]
 name = "jeepney"
 version = "0.7.1"
 description = "Low-level, pure Python DBus protocol wrapper."
@@ -1205,7 +1191,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "fd0cba4119e7cd02cfeaef6bd0094bf1fa438678a58a9697d7501e727e968865"
+content-hash = "1847f7409692baba70116b4af1f11d58a94f5f58f658a1662baf1aae64a1910c"
 
 [metadata.files]
 aiodns = [
@@ -1752,10 +1738,6 @@ importlib-metadata = [
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
-]
-isort = [
-    {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
-    {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
 ]
 jeepney = [
     {file = "jeepney-0.7.1-py3-none-any.whl", hash = "sha256:1b5a0ea5c0e7b166b2f5895b91a08c14de8915afda4407fb5022a195224958ac"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ Jinja2 = "^3.0.3"
 
 [tool.poetry.dev-dependencies]
 black = "^22.1.0"
-isort = "^5.10.1"
 mypy = "^0.931"
 
 safety = "^1.10"

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,17 +3,6 @@
 # https://docs.python.org/3/distutils/configfile.html
 
 
-[isort]
-# isort configuration:
-# https://pycqa.github.io/isort/docs/configuration/options.html
-line_length = 80
-atomic = true
-include_trailing_comma = true
-use_parentheses = true
-# See https://github.com/timothycrosley/isort#multi-line-output-modes
-multi_line_output = 3
-
-
 [tool:pytest]
 # Directories that are not visited by pytest collector:
 norecursedirs = *.egg .eggs dist build docs .tox .git __pycache__
@@ -43,7 +32,7 @@ disallow_any_generics = True
 disallow_untyped_calls = True
 ignore_errors = False
 ignore_missing_imports = True
-implicit_reexport = False
+implicit_reexport = True
 local_partial_types = True
 strict_optional = True
 strict_equality = True


### PR DESCRIPTION
isort сортирует импорты по алфавиту, длине. Это ломает основной __init__.py, т.к. создаётся круговой импорт.﻿
