### PR TITLE
Remove Python3.11 from CICD

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11-dev']
+        python-version: ['3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Версия 0.2.0
 
 - Переписали все на фреймворк [aiohttp](https://pypi.org/project/aiohttp) вместо [Django](https://pypi.org/project/Django). ([aiohttp ветвь](https://github.com/fire-squad/autodonate/tree/aiohttp))
+- Убрали поддержку Python 3.11-dev. ([#36](https://github.com/fire-squad/autodonate/pull/36))
 
 ## Версия 0.1.2
 


### PR DESCRIPTION
<!--
    Спасибо за вклад в наш проект!
-->

# Убрать Python 3.11 из автоматического тестирования

[Одна из зависимостей](https://github.com/PyYoshi/cChardet/issues/77) не поддерживает Python 3.11. Сейчас, лучший путь это временно убрать Python3.11-dev из CI тестирования.

# Важный check-list

- [x] Я написал подробное описание моих изменений.
- [x] Я написал подробную причину моих изменений.
- [x] Я точно прочитал и использовал все пункты [этого списка](https://github.com/fire-squad/autodonate/blob/master/CONTRIBUTING.md#перед-началом-работы).
- [x] Я записал изменение в `CHANGELOG.md` и добавил номер PR туда.
- [x] Я запустил `make test` и с тех пор ничего не менял.
